### PR TITLE
Write Defaults Off Fix

### DIFF
--- a/FaceTrackingSetup/Scripts/Editor/FaceTrackingSetup_Editor.cs
+++ b/FaceTrackingSetup/Scripts/Editor/FaceTrackingSetup_Editor.cs
@@ -403,11 +403,14 @@ namespace ImTiara.FaceTrackingSetup
 
                         fts.leftWideAnimation = (AnimationClip)EditorGUILayout.ObjectField("Left Wide", fts.leftWideAnimation, typeof(AnimationClip), false);
                         fts.rightWideAnimation = (AnimationClip)EditorGUILayout.ObjectField("Right Wide", fts.rightWideAnimation, typeof(AnimationClip), false);
-                        
-                        GUILayout.Space(10);
 
-                        fts.leftIdleAnimation = (AnimationClip)EditorGUILayout.ObjectField("Left Idle", fts.leftIdleAnimation, typeof(AnimationClip), false);
-                        fts.rightIdleAnimation = (AnimationClip)EditorGUILayout.ObjectField("Right Idle", fts.rightIdleAnimation, typeof(AnimationClip), false);
+                        if (!fts.fxWriteDefaults)
+                        {
+                            GUILayout.Space(10);
+
+                            fts.leftIdleAnimation = (AnimationClip)EditorGUILayout.ObjectField("Left Idle", fts.leftIdleAnimation, typeof(AnimationClip), false);
+                            fts.rightIdleAnimation = (AnimationClip)EditorGUILayout.ObjectField("Right Idle", fts.rightIdleAnimation, typeof(AnimationClip), false);
+                        }
                         break;
                 }
 
@@ -805,7 +808,7 @@ namespace ImTiara.FaceTrackingSetup
                 CreateEyeTracking(fts, additive, fx, _do_nothing);
                 CreateEyeBlink(fts, fx, _do_nothing);
                 CreateEyeDilation(fts, fx, _do_nothing);
-                CreateMouthTracking(fts, fx);
+                CreateMouthTracking(fts, fx, _do_nothing);
 
                 EditorUtility.DisplayProgressBar("Face Tracking Setup", "Saving", 1.0f);
 
@@ -994,32 +997,37 @@ namespace ImTiara.FaceTrackingSetup
                         eyeLeftIdle = new AnimationClip();
                         eyeRightIdle = new AnimationClip();
 
-                        eyeLeftBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
                         eyeLeftBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftBlinkShapeKey}", AnimationCurve.Constant(0, 0, 100));
-                        AssetDatabase.CreateAsset(eyeLeftBlink, $"{fts.outputPath}/Blinking/Eye_Left_Blink.anim");
 
-                        eyeRightBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
                         eyeRightBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightBlinkShapeKey}", AnimationCurve.Constant(0, 0, 100));
-                        AssetDatabase.CreateAsset(eyeRightBlink, $"{fts.outputPath}/Blinking/Eye_Right_Blink.anim");
 
                         eyeLeftWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftWideShapeKey}", AnimationCurve.Constant(0, 0, 100));
-                        eyeLeftWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
-                        AssetDatabase.CreateAsset(eyeLeftWide, $"{fts.outputPath}/Blinking/Eye_Left_Wide.anim");
 
                         eyeRightWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightWideShapeKey}", AnimationCurve.Constant(0, 0, 100));
-                        eyeRightWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
+
+                        if (!fts.fxWriteDefaults)
+                        {
+                            eyeLeftBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
+
+                            eyeRightBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
+
+                            eyeLeftWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
+
+                            eyeRightWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
+
+                            eyeLeftIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                            eyeLeftIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                            AssetDatabase.CreateAsset(eyeLeftIdle, $"{fts.outputPath}/Blinking/Eye_Left_Idle.anim");
+                            
+                            eyeRightIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                            eyeRightIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                            AssetDatabase.CreateAsset(eyeRightIdle, $"{fts.outputPath}/Blinking/Eye_Right_Idle.anim");
+                        }
+
+                        AssetDatabase.CreateAsset(eyeLeftWide, $"{fts.outputPath}/Blinking/Eye_Left_Wide.anim");
+                        AssetDatabase.CreateAsset(eyeLeftBlink, $"{fts.outputPath}/Blinking/Eye_Left_Blink.anim");
+                        AssetDatabase.CreateAsset(eyeRightBlink, $"{fts.outputPath}/Blinking/Eye_Right_Blink.anim");
                         AssetDatabase.CreateAsset(eyeRightWide, $"{fts.outputPath}/Blinking/Eye_Right_Wide.anim");
-
-                        eyeLeftIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
-                        eyeLeftIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
-                        AssetDatabase.CreateAsset(eyeLeftIdle, $"{fts.outputPath}/Blinking/Eye_Left_Idle.anim");
-
-                        eyeRightIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
-                        eyeRightIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
-                        AssetDatabase.CreateAsset(eyeRightIdle, $"{fts.outputPath}/Blinking/Eye_Right_Idle.anim");
-
-
-
                         break;
                     case FaceTrackingSetup.BlinkingMode.Animation:
                         eyeLeftBlink = fts.leftBlinkAnimation;
@@ -1071,20 +1079,20 @@ namespace ImTiara.FaceTrackingSetup
                 {
                     case FaceTrackingSetup.BlinkingMode.BlendShape:
                         leftEyeLidBlendTree.AddChild(fts.leftBlinkShapeKey != FaceTrackingSetup.NONE ? eyeLeftBlink : _do_nothing, fts.blinkingThreshold_Blink);
-                        leftEyeLidBlendTree.AddChild(eyeLeftIdle, fts.blinkingThreshold_Normal);
+                        leftEyeLidBlendTree.AddChild(fts.fxWriteDefaults ? _do_nothing : eyeLeftIdle, fts.blinkingThreshold_Normal);
                         leftEyeLidBlendTree.AddChild(fts.leftWideShapeKey != FaceTrackingSetup.NONE ? eyeLeftWide : _do_nothing, fts.blinkingThreshold_Wide);
 
                         rightEyeLidBlendTree.AddChild(fts.rightBlinkShapeKey != FaceTrackingSetup.NONE ? eyeRightBlink : _do_nothing, fts.blinkingThreshold_Blink);
-                        rightEyeLidBlendTree.AddChild(eyeRightIdle, fts.blinkingThreshold_Normal);
+                        rightEyeLidBlendTree.AddChild(fts.fxWriteDefaults ? _do_nothing : eyeRightIdle, fts.blinkingThreshold_Normal);
                         rightEyeLidBlendTree.AddChild(fts.rightWideShapeKey != FaceTrackingSetup.NONE ? eyeRightWide : _do_nothing, fts.blinkingThreshold_Wide);
                         break;
                     case FaceTrackingSetup.BlinkingMode.Animation:
                         leftEyeLidBlendTree.AddChild(eyeLeftBlink, fts.blinkingThreshold_Blink);
-                        leftEyeLidBlendTree.AddChild(eyeLeftIdle, fts.blinkingThreshold_Normal);
+                        leftEyeLidBlendTree.AddChild(fts.fxWriteDefaults ? _do_nothing : eyeLeftIdle, fts.blinkingThreshold_Normal);
                         leftEyeLidBlendTree.AddChild(eyeLeftWide, fts.blinkingThreshold_Wide);
 
                         rightEyeLidBlendTree.AddChild(eyeRightBlink, fts.blinkingThreshold_Blink);
-                        rightEyeLidBlendTree.AddChild(eyeRightIdle, fts.blinkingThreshold_Normal);
+                        rightEyeLidBlendTree.AddChild(fts.fxWriteDefaults ? _do_nothing : eyeRightIdle, fts.blinkingThreshold_Normal);
                         rightEyeLidBlendTree.AddChild(eyeRightWide, fts.blinkingThreshold_Wide);
                         break;
                 }
@@ -1121,12 +1129,15 @@ namespace ImTiara.FaceTrackingSetup
                 AnimationClip eyeConstricted = new AnimationClip();
 
                 eyeDilated.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.dilatedShapeKey}", AnimationCurve.Constant(0, 0, 100));
-                eyeDilated.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.constrictedShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                if (!fts.fxWriteDefaults) eyeDilated.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.constrictedShapeKey}", AnimationCurve.Constant(0, 0, 0));
                 AssetDatabase.CreateAsset(eyeDilated, $"{fts.outputPath}/Pupils/Eye_Dilated.anim");
 
-                eyeNormal.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.dilatedShapeKey}", AnimationCurve.Constant(0, 0, 0));
-                eyeNormal.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.constrictedShapeKey}", AnimationCurve.Constant(0, 0, 0));
-                AssetDatabase.CreateAsset(eyeNormal, $"{fts.outputPath}/Pupils/Eye_Normal.anim");
+                if (!fts.fxWriteDefaults)
+                {
+                    eyeNormal.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.dilatedShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                    eyeNormal.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.constrictedShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                    AssetDatabase.CreateAsset(eyeNormal, $"{fts.outputPath}/Pupils/Eye_Normal.anim");
+                }
 
                 eyeConstricted.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.dilatedShapeKey}", AnimationCurve.Constant(0, 0, 0));
                 eyeConstricted.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.constrictedShapeKey}", AnimationCurve.Constant(0, 0, 100));
@@ -1136,7 +1147,7 @@ namespace ImTiara.FaceTrackingSetup
 
                 BlendTree blendTree = new BlendTree() { name = "Pupil", blendParameter = "EyesDilation", useAutomaticThresholds = false };
                 blendTree.AddChild(fts.constrictedShapeKey != FaceTrackingSetup.NONE ? eyeConstricted : _do_nothing, fts.pupilsThreshold_Constricted);
-                blendTree.AddChild(eyeNormal, fts.pupilsThreshold_Normal);
+                blendTree.AddChild(fts.fxWriteDefaults ? _do_nothing : eyeNormal, fts.pupilsThreshold_Normal);
                 blendTree.AddChild(fts.dilatedShapeKey != FaceTrackingSetup.NONE ? eyeDilated : _do_nothing, fts.pupilsThreshold_Dilated);
                 blendTree.hideFlags = HideFlags.HideInHierarchy;
                 var state = eyeDilationLayer.stateMachine.AddState("Pupil");
@@ -1154,7 +1165,7 @@ namespace ImTiara.FaceTrackingSetup
             }
         }
 
-        public static void CreateMouthTracking(FaceTrackingSetup fts, AnimatorController fx)
+        public static void CreateMouthTracking(FaceTrackingSetup fts, AnimatorController fx, AnimationClip _do_nothing)
         {
             if (fts.mouthEnable)
             {
@@ -1173,12 +1184,12 @@ namespace ImTiara.FaceTrackingSetup
                     {
                         if (trackedMouth.affectedBlendshapes[i2].blendShape.Length == 0 || trackedMouth.affectedBlendshapes[i2].blendShape == FaceTrackingSetup.NONE) continue;
                         
-                        clipIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{trackedMouth.affectedBlendshapes[i2].blendShape}", AnimationCurve.Constant(0, 0, 0));
+                        if (!fts.fxWriteDefaults) clipIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{trackedMouth.affectedBlendshapes[i2].blendShape}", AnimationCurve.Constant(0, 0, 0));
                         clip.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{trackedMouth.affectedBlendshapes[i2].blendShape}", AnimationCurve.Constant(0, 0, trackedMouth.affectedBlendshapes[i2].weight));
                     }
                     
                     AssetDatabase.CreateAsset(clip, $"{fts.outputPath}/Mouth/{FaceTrackingSetup.mouthParameterNames[i]}.anim");
-                    AssetDatabase.CreateAsset(clipIdle, $"{fts.outputPath}/Mouth/{FaceTrackingSetup.mouthParameterNames[i]}_Idle.anim");
+                    if (!fts.fxWriteDefaults) AssetDatabase.CreateAsset(clipIdle, $"{fts.outputPath}/Mouth/{FaceTrackingSetup.mouthParameterNames[i]}_Idle.anim");
 
                     switch (trackedMouth.type)
                     {
@@ -1189,7 +1200,7 @@ namespace ImTiara.FaceTrackingSetup
                             AddAnimatorParameter(fx, FaceTrackingSetup.mouthParameterNames[i], AnimatorControllerParameterType.Float, 0.0f);
 
                             BlendTree blendTree = new BlendTree() { name = FaceTrackingSetup.mouthParameterNames[i], blendParameter = FaceTrackingSetup.mouthParameterNames[i], useAutomaticThresholds = false };
-                            blendTree.AddChild(clipIdle, 0.0f);
+                            blendTree.AddChild(fts.fxWriteDefaults ? _do_nothing : clipIdle, 0.0f);
                             blendTree.AddChild(clip, 1.0f);
                             blendTree.hideFlags = HideFlags.HideInHierarchy;
                             var state = layer.stateMachine.AddState(FaceTrackingSetup.mouthParameterNames[i]);

--- a/FaceTrackingSetup/Scripts/Editor/FaceTrackingSetup_Editor.cs
+++ b/FaceTrackingSetup/Scripts/Editor/FaceTrackingSetup_Editor.cs
@@ -403,6 +403,11 @@ namespace ImTiara.FaceTrackingSetup
 
                         fts.leftWideAnimation = (AnimationClip)EditorGUILayout.ObjectField("Left Wide", fts.leftWideAnimation, typeof(AnimationClip), false);
                         fts.rightWideAnimation = (AnimationClip)EditorGUILayout.ObjectField("Right Wide", fts.rightWideAnimation, typeof(AnimationClip), false);
+                        
+                        GUILayout.Space(10);
+
+                        fts.leftIdleAnimation = (AnimationClip)EditorGUILayout.ObjectField("Left Idle", fts.leftIdleAnimation, typeof(AnimationClip), false);
+                        fts.rightIdleAnimation = (AnimationClip)EditorGUILayout.ObjectField("Right Idle", fts.rightIdleAnimation, typeof(AnimationClip), false);
                         break;
                 }
 
@@ -432,6 +437,8 @@ namespace ImTiara.FaceTrackingSetup
                         fts.rightBlinkAnimation = null;
                         fts.leftWideAnimation = null;
                         fts.rightWideAnimation = null;
+                        fts.leftIdleAnimation = null;
+                        fts.rightIdleAnimation = null;
 
                         Save(fts);
                     }
@@ -798,7 +805,7 @@ namespace ImTiara.FaceTrackingSetup
                 CreateEyeTracking(fts, additive, fx, _do_nothing);
                 CreateEyeBlink(fts, fx, _do_nothing);
                 CreateEyeDilation(fts, fx, _do_nothing);
-                CreateMouthTracking(fts, fx, _do_nothing);
+                CreateMouthTracking(fts, fx);
 
                 EditorUtility.DisplayProgressBar("Face Tracking Setup", "Saving", 1.0f);
 
@@ -971,6 +978,9 @@ namespace ImTiara.FaceTrackingSetup
                 AnimationClip eyeRightBlink = null;
                 AnimationClip eyeLeftWide = null;
                 AnimationClip eyeRightWide = null;
+                AnimationClip eyeLeftIdle = null;
+                AnimationClip eyeRightIdle = null;
+
 
                 switch (fts.blinkingMode)
                 {
@@ -981,6 +991,9 @@ namespace ImTiara.FaceTrackingSetup
                         eyeRightBlink = new AnimationClip();
                         eyeLeftWide = new AnimationClip();
                         eyeRightWide = new AnimationClip();
+                        eyeLeftIdle = new AnimationClip();
+                        eyeRightIdle = new AnimationClip();
+
 
                         eyeLeftBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftBlinkShapeKey}", AnimationCurve.Constant(0, 0, 100));
                         AssetDatabase.CreateAsset(eyeLeftBlink, $"{fts.outputPath}/Blinking/Eye_Left_Blink.anim");
@@ -993,12 +1006,25 @@ namespace ImTiara.FaceTrackingSetup
 
                         eyeRightWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightWideShapeKey}", AnimationCurve.Constant(0, 0, 100));
                         AssetDatabase.CreateAsset(eyeRightWide, $"{fts.outputPath}/Blinking/Eye_Right_Wide.anim");
+
+                        eyeLeftIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                        eyeLeftIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                        AssetDatabase.CreateAsset(eyeLeftIdle, $"{fts.outputPath}/Blinking/Eye_Left_Idle.anim");
+
+                        eyeRightIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                        eyeRightIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                        AssetDatabase.CreateAsset(eyeRightIdle, $"{fts.outputPath}/Blinking/Eye_Right_Idle.anim");
+
+
+
                         break;
                     case FaceTrackingSetup.BlinkingMode.Animation:
                         eyeLeftBlink = fts.leftBlinkAnimation;
                         eyeRightBlink = fts.rightBlinkAnimation;
                         eyeLeftWide = fts.leftWideAnimation;
                         eyeRightWide = fts.rightWideAnimation;
+                        eyeLeftIdle = fts.leftIdleAnimation;
+                        eyeRightIdle = fts.rightIdleAnimation;
                         break;
                 }
 
@@ -1042,20 +1068,20 @@ namespace ImTiara.FaceTrackingSetup
                 {
                     case FaceTrackingSetup.BlinkingMode.BlendShape:
                         leftEyeLidBlendTree.AddChild(fts.leftBlinkShapeKey != FaceTrackingSetup.NONE ? eyeLeftBlink : _do_nothing, fts.blinkingThreshold_Blink);
-                        leftEyeLidBlendTree.AddChild(_do_nothing, fts.blinkingThreshold_Normal);
+                        leftEyeLidBlendTree.AddChild(eyeLeftIdle, fts.blinkingThreshold_Normal);
                         leftEyeLidBlendTree.AddChild(fts.leftWideShapeKey != FaceTrackingSetup.NONE ? eyeLeftWide : _do_nothing, fts.blinkingThreshold_Wide);
 
                         rightEyeLidBlendTree.AddChild(fts.rightBlinkShapeKey != FaceTrackingSetup.NONE ? eyeRightBlink : _do_nothing, fts.blinkingThreshold_Blink);
-                        rightEyeLidBlendTree.AddChild(_do_nothing, fts.blinkingThreshold_Normal);
+                        rightEyeLidBlendTree.AddChild(eyeRightIdle, fts.blinkingThreshold_Normal);
                         rightEyeLidBlendTree.AddChild(fts.rightWideShapeKey != FaceTrackingSetup.NONE ? eyeRightWide : _do_nothing, fts.blinkingThreshold_Wide);
                         break;
                     case FaceTrackingSetup.BlinkingMode.Animation:
                         leftEyeLidBlendTree.AddChild(eyeLeftBlink, fts.blinkingThreshold_Blink);
-                        leftEyeLidBlendTree.AddChild(_do_nothing, fts.blinkingThreshold_Normal);
+                        leftEyeLidBlendTree.AddChild(eyeLeftIdle, fts.blinkingThreshold_Normal);
                         leftEyeLidBlendTree.AddChild(eyeLeftWide, fts.blinkingThreshold_Wide);
 
                         rightEyeLidBlendTree.AddChild(eyeRightBlink, fts.blinkingThreshold_Blink);
-                        rightEyeLidBlendTree.AddChild(_do_nothing, fts.blinkingThreshold_Normal);
+                        rightEyeLidBlendTree.AddChild(eyeRightIdle, fts.blinkingThreshold_Normal);
                         rightEyeLidBlendTree.AddChild(eyeRightWide, fts.blinkingThreshold_Wide);
                         break;
                 }
@@ -1088,10 +1114,15 @@ namespace ImTiara.FaceTrackingSetup
 
                 EditorUtility.DisplayProgressBar("Face Tracking Setup - Pupil Dilation", "Creating pupil animations", 0.0f);
                 AnimationClip eyeDilated = new AnimationClip();
+                AnimationClip eyeNormal = new AnimationClip();
                 AnimationClip eyeConstricted = new AnimationClip();
 
                 eyeDilated.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.dilatedShapeKey}", AnimationCurve.Constant(0, 0, 100));
                 AssetDatabase.CreateAsset(eyeDilated, $"{fts.outputPath}/Pupils/Eye_Dilated.anim");
+
+                eyeNormal.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.dilatedShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                eyeNormal.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.constrictedShapeKey}", AnimationCurve.Constant(0, 0, 0));
+                AssetDatabase.CreateAsset(eyeNormal, $"{fts.outputPath}/Pupils/Eye_Normal.anim");
 
                 eyeConstricted.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.constrictedShapeKey}", AnimationCurve.Constant(0, 0, 100));
                 AssetDatabase.CreateAsset(eyeConstricted, $"{fts.outputPath}/Pupils/Eye_Constricted.anim");
@@ -1100,7 +1131,7 @@ namespace ImTiara.FaceTrackingSetup
 
                 BlendTree blendTree = new BlendTree() { name = "Pupil", blendParameter = "EyesDilation", useAutomaticThresholds = false };
                 blendTree.AddChild(fts.constrictedShapeKey != FaceTrackingSetup.NONE ? eyeConstricted : _do_nothing, fts.pupilsThreshold_Constricted);
-                blendTree.AddChild(_do_nothing, fts.pupilsThreshold_Normal);
+                blendTree.AddChild(eyeNormal, fts.pupilsThreshold_Normal);
                 blendTree.AddChild(fts.dilatedShapeKey != FaceTrackingSetup.NONE ? eyeDilated : _do_nothing, fts.pupilsThreshold_Dilated);
                 blendTree.hideFlags = HideFlags.HideInHierarchy;
                 var state = eyeDilationLayer.stateMachine.AddState("Pupil");
@@ -1118,7 +1149,7 @@ namespace ImTiara.FaceTrackingSetup
             }
         }
 
-        public static void CreateMouthTracking(FaceTrackingSetup fts, AnimatorController fx, AnimationClip _do_nothing)
+        public static void CreateMouthTracking(FaceTrackingSetup fts, AnimatorController fx)
         {
             if (fts.mouthEnable)
             {
@@ -1132,14 +1163,17 @@ namespace ImTiara.FaceTrackingSetup
                     if (count == 0) continue;
 
                     AnimationClip clip = new AnimationClip();
+                    AnimationClip clipIdle = new AnimationClip();
                     for (int i2 = 0; i2 < count; i2++)
                     {
                         if (trackedMouth.affectedBlendshapes[i2].blendShape.Length == 0 || trackedMouth.affectedBlendshapes[i2].blendShape == FaceTrackingSetup.NONE) continue;
                         
+                        clipIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{trackedMouth.affectedBlendshapes[i2].blendShape}", AnimationCurve.Constant(0, 0, 0));
                         clip.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{trackedMouth.affectedBlendshapes[i2].blendShape}", AnimationCurve.Constant(0, 0, trackedMouth.affectedBlendshapes[i2].weight));
                     }
                     
                     AssetDatabase.CreateAsset(clip, $"{fts.outputPath}/Mouth/{FaceTrackingSetup.mouthParameterNames[i]}.anim");
+                    AssetDatabase.CreateAsset(clipIdle, $"{fts.outputPath}/Mouth/{FaceTrackingSetup.mouthParameterNames[i]}_Idle.anim");
 
                     switch (trackedMouth.type)
                     {
@@ -1150,7 +1184,7 @@ namespace ImTiara.FaceTrackingSetup
                             AddAnimatorParameter(fx, FaceTrackingSetup.mouthParameterNames[i], AnimatorControllerParameterType.Float, 0.0f);
 
                             BlendTree blendTree = new BlendTree() { name = FaceTrackingSetup.mouthParameterNames[i], blendParameter = FaceTrackingSetup.mouthParameterNames[i], useAutomaticThresholds = false };
-                            blendTree.AddChild(_do_nothing, 0.0f);
+                            blendTree.AddChild(clipIdle, 0.0f);
                             blendTree.AddChild(clip, 1.0f);
                             blendTree.hideFlags = HideFlags.HideInHierarchy;
                             var state = layer.stateMachine.AddState(FaceTrackingSetup.mouthParameterNames[i]);

--- a/FaceTrackingSetup/Scripts/Editor/FaceTrackingSetup_Editor.cs
+++ b/FaceTrackingSetup/Scripts/Editor/FaceTrackingSetup_Editor.cs
@@ -75,7 +75,7 @@ namespace ImTiara.FaceTrackingSetup
                 {
                     tempList.Add(fts.faceMesh.sharedMesh.GetBlendShapeName(i));
                 }
-                
+
                 blendShapes = tempList.ToArray();
             }
 
@@ -107,7 +107,7 @@ namespace ImTiara.FaceTrackingSetup
 
                 EditorGUI.indentLevel--;
             }
-            
+
             GUILayout.Space(20);
 
             fts.isShowingEyeTrackingSettings = EditorGUILayout.Foldout(fts.isShowingEyeTrackingSettings, "Eye Tracking", true);
@@ -122,7 +122,7 @@ namespace ImTiara.FaceTrackingSetup
                 GUILayout.Space(10);
 
                 GUI.enabled = fts.enableEyeTracking;
-                
+
                 fts.eyeTrackingMode = (FaceTrackingSetup.EyeTrackingMode)EditorGUILayout.Popup("Mode", (int)fts.eyeTrackingMode, new string[2] { "Eye Bones", "Blendshapes" });
                 switch(fts.eyeTrackingMode)
                 {
@@ -207,7 +207,7 @@ namespace ImTiara.FaceTrackingSetup
                                 fts.leftrightShapeKey = "eyeLookInLeft";
                                 fts.leftupShapeKey = "eyeLookUpLeft";
                                 fts.leftdownShapeKey = "eyeLookDownLeft";
-                                
+
                                 fts.rightleftShapeKey = "eyeLookInRight";
                                 fts.rightrightShapeKey = "eyeLookOutRight";
                                 fts.rightupShapeKey = "eyeLookUpRight";
@@ -356,7 +356,7 @@ namespace ImTiara.FaceTrackingSetup
 
                                 if (name == fts.leftBlinkShapeKey) selectedLeftBlinkShapekeyIndex = i;
                                 if (name == fts.rightBlinkShapeKey) selectedRightBlinkShapekeyIndex = i;
-                                
+
                                 if (name == fts.leftWideShapeKey) selectedLeftWideShapekeyIndex = i;
                                 if (name == fts.rightWideShapeKey) selectedRightWideShapekeyIndex = i;
                             }
@@ -621,7 +621,7 @@ namespace ImTiara.FaceTrackingSetup
                         if (EditorUtility.DisplayDialog("Face Tracking Setup", "Are you sure you want to reset the mouth settings to the default values?", "Reset", "Cancel"))
                         {
                             fts.mouthAffectors = new FaceTrackingSetup.MouthAffector[37];
-                            
+
                             Save(fts);
                         }
                     }
@@ -745,7 +745,7 @@ namespace ImTiara.FaceTrackingSetup
                 }
             }
             GUI.backgroundColor = Color.white;
-            
+
             GUI.enabled = true;
 
             GUILayout.Space(10);
@@ -802,7 +802,7 @@ namespace ImTiara.FaceTrackingSetup
                     AddAnimatorParameter(fx, FaceTrackingSetup.MOUTH_TRACKING_TOGGLE_PARAMETER, AnimatorControllerParameterType.Bool, true);
                     AddVRCParameter(fts.expressionParameters, FaceTrackingSetup.MOUTH_TRACKING_TOGGLE_PARAMETER, VRCExpressionParameters.ValueType.Bool, 1, true);
                 }
-                
+
                 EditorUtility.DisplayProgressBar("Face Tracking Setup - Initiating", "Done", 1.0f);
 
                 CreateEyeTracking(fts, additive, fx, _do_nothing);
@@ -936,30 +936,30 @@ namespace ImTiara.FaceTrackingSetup
                 rightEyeState.motion = rightEyeBlendTree;
 
                 rightEyeState.timeParameterActive = false;
-               
+
 
                 switch(fts.eyeTrackingMode)
                 {
                     case FaceTrackingSetup.EyeTrackingMode.EyeBone:
                         leftEyeState.writeDefaultValues = fts.additiveWriteDefaults;
                         rightEyeState.writeDefaultValues = fts.additiveWriteDefaults;
-                        
+
                         AssetDatabase.AddObjectToAsset(leftEyeBlendTree, AssetDatabase.GetAssetPath(additive));
                         AssetDatabase.AddObjectToAsset(rightEyeBlendTree, AssetDatabase.GetAssetPath(additive));
                         break;
                     case FaceTrackingSetup.EyeTrackingMode.BlendShape:
                         leftEyeState.writeDefaultValues = fts.fxWriteDefaults;
                         rightEyeState.writeDefaultValues = fts.fxWriteDefaults;
-                        
+
                         AssetDatabase.AddObjectToAsset(leftEyeBlendTree, AssetDatabase.GetAssetPath(fx));
                         AssetDatabase.AddObjectToAsset(rightEyeBlendTree, AssetDatabase.GetAssetPath(fx));
                         break;
                 }
-                
+
                 if (fts.createEyeTrackingToggle)
                 {
-                    CreateToggle(leftEyeLayer, leftEyeState, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, fts.eyeTrackingMode == FaceTrackingSetup.EyeTrackingMode.EyeBone ? fts.additiveWriteDefaults : fts.fxWriteDefaults);
-                    CreateToggle(rightEyeLayer, rightEyeState, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, fts.eyeTrackingMode == FaceTrackingSetup.EyeTrackingMode.EyeBone ? fts.additiveWriteDefaults : fts.fxWriteDefaults);
+                    CreateToggle(leftEyeLayer, leftEyeState, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, fts.eyeTrackingMode == FaceTrackingSetup.EyeTrackingMode.EyeBone ? fts.additiveWriteDefaults : fts.fxWriteDefaults, _do_nothing);
+                    CreateToggle(rightEyeLayer, rightEyeState, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, fts.eyeTrackingMode == FaceTrackingSetup.EyeTrackingMode.EyeBone ? fts.additiveWriteDefaults : fts.fxWriteDefaults, _do_nothing);
                 }
 
                 EditorUtility.ClearProgressBar();
@@ -1018,7 +1018,7 @@ namespace ImTiara.FaceTrackingSetup
                             eyeLeftIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
                             eyeLeftIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
                             AssetDatabase.CreateAsset(eyeLeftIdle, $"{fts.outputPath}/Blinking/Eye_Left_Idle.anim");
-                            
+
                             eyeRightIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
                             eyeRightIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
                             AssetDatabase.CreateAsset(eyeRightIdle, $"{fts.outputPath}/Blinking/Eye_Right_Idle.anim");
@@ -1074,7 +1074,7 @@ namespace ImTiara.FaceTrackingSetup
                 rightEyeLidState.writeDefaultValues = fts.fxWriteDefaults;
                 rightEyeLidState.timeParameterActive = false;
                 AssetDatabase.AddObjectToAsset(rightEyeLidBlendTree, AssetDatabase.GetAssetPath(fx));
-        
+
                 switch(fts.blinkingMode)
                 {
                     case FaceTrackingSetup.BlinkingMode.BlendShape:
@@ -1099,8 +1099,8 @@ namespace ImTiara.FaceTrackingSetup
 
                 if (fts.createEyeTrackingToggle)
                 {
-                    CreateToggle(leftEyeLidExpandedLayer, leftEyeLidState, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, fts.fxWriteDefaults);
-                    CreateToggle(rightEyeLidExpandedLayer, rightEyeLidState, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, fts.fxWriteDefaults);
+                    CreateToggle(leftEyeLidExpandedLayer, leftEyeLidState, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, fts.fxWriteDefaults, fts.fxWriteDefaults ? _do_nothing : eyeLeftIdle);
+                    CreateToggle(rightEyeLidExpandedLayer, rightEyeLidState, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, fts.fxWriteDefaults, fts.fxWriteDefaults ? _do_nothing : eyeRightIdle);
                 }
 
                 EditorUtility.ClearProgressBar();
@@ -1158,7 +1158,7 @@ namespace ImTiara.FaceTrackingSetup
 
                 if (fts.createEyeTrackingToggle)
                 {
-                    CreateToggle(eyeDilationLayer, state, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, fts.fxWriteDefaults);
+                    CreateToggle(eyeDilationLayer, state, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, fts.fxWriteDefaults, fts.fxWriteDefaults ? _do_nothing : eyeNormal);
                 }
 
                 EditorUtility.ClearProgressBar();
@@ -1183,11 +1183,11 @@ namespace ImTiara.FaceTrackingSetup
                     for (int i2 = 0; i2 < count; i2++)
                     {
                         if (trackedMouth.affectedBlendshapes[i2].blendShape.Length == 0 || trackedMouth.affectedBlendshapes[i2].blendShape == FaceTrackingSetup.NONE) continue;
-                        
+
                         if (!fts.fxWriteDefaults) clipIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{trackedMouth.affectedBlendshapes[i2].blendShape}", AnimationCurve.Constant(0, 0, 0));
                         clip.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{trackedMouth.affectedBlendshapes[i2].blendShape}", AnimationCurve.Constant(0, 0, trackedMouth.affectedBlendshapes[i2].weight));
                     }
-                    
+
                     AssetDatabase.CreateAsset(clip, $"{fts.outputPath}/Mouth/{FaceTrackingSetup.mouthParameterNames[i]}.anim");
                     if (!fts.fxWriteDefaults) AssetDatabase.CreateAsset(clipIdle, $"{fts.outputPath}/Mouth/{FaceTrackingSetup.mouthParameterNames[i]}_Idle.anim");
 
@@ -1211,10 +1211,10 @@ namespace ImTiara.FaceTrackingSetup
 
                             if (fts.createEyeTrackingToggle)
                             {
-                                CreateToggle(layer, state, FaceTrackingSetup.MOUTH_TRACKING_TOGGLE_PARAMETER, fts.fxWriteDefaults);
+                                CreateToggle(layer, state, FaceTrackingSetup.MOUTH_TRACKING_TOGGLE_PARAMETER, fts.fxWriteDefaults, fts.fxWriteDefaults ? _do_nothing : clipIdle);
                             }
                             break;
-                            
+
                             /// TODO: Add binary support
                     }
                 }
@@ -1223,16 +1223,16 @@ namespace ImTiara.FaceTrackingSetup
             }
         }
         #endregion
-        
+
         #region Removers
         public void RemoveAll()
         {
             EditorUtility.DisplayProgressBar("Face Tracking Setup", "Removing existing setup", 0.0f);
-            
+
             FaceTrackingSetup fts = (FaceTrackingSetup)target;
             var additive = fts.additive != null ? AssetDatabase.LoadAssetAtPath<AnimatorController>(AssetDatabase.GetAssetPath(fts.additive)) : null;
             var fx = AssetDatabase.LoadAssetAtPath<AnimatorController>(AssetDatabase.GetAssetPath(fts.fx));
-            
+
             RemoveEyeTracking(fts, additive, fx);
             RemoveEyeBlink(fts, fx);
             RemoveEyeDilation(fts, fx);
@@ -1242,7 +1242,7 @@ namespace ImTiara.FaceTrackingSetup
             RemoveVRCParameters(fts.expressionParameters, FaceTrackingSetup.EYE_TRACKING_TOGGLE_PARAMETER, FaceTrackingSetup.MOUTH_TRACKING_TOGGLE_PARAMETER);
 
             EditorUtility.DisplayProgressBar("Face Tracking Setup", "Removing existing setup", 1.0f);
-            
+
             EditorUtility.ClearProgressBar();
         }
 
@@ -1253,7 +1253,7 @@ namespace ImTiara.FaceTrackingSetup
                 RemoveLayers(additive, "Left Eye", "Right Eye");
                 RemoveAnimatorParameters(additive, "LeftEyeX", "RightEyeX", "EyesY");
             }
-            
+
             RemoveLayers(fx, "Left Eye", "Right Eye");
             RemoveAnimatorParameters(fx, "LeftEyeX", "RightEyeX", "EyesY");
             RemoveVRCParameters(fts.expressionParameters, "LeftEyeX", "RightEyeX", "EyesY");
@@ -1294,10 +1294,10 @@ namespace ImTiara.FaceTrackingSetup
                     hideFlags = HideFlags.HideInHierarchy,
                 }
             };
-                
+
             AssetDatabase.AddObjectToAsset(layer.stateMachine, AssetDatabase.GetAssetPath(controller));
             controller.AddLayer(layer);
-            
+
             return layer;
         }
 
@@ -1392,10 +1392,11 @@ namespace ImTiara.FaceTrackingSetup
             vrcParameters.parameters = _parameters.ToArray();
         }
 
-        public static void CreateToggle(AnimatorControllerLayer layer, AnimatorState animatorState, string parameter, bool writeDefaults)
+        public static void CreateToggle(AnimatorControllerLayer layer, AnimatorState animatorState, string parameter, bool writeDefaults, AnimationClip clip)
         {
             var disable = layer.stateMachine.AddState("Disable");
             disable.writeDefaultValues = writeDefaults;
+            disable.motion = clip;
             var onToDisable = animatorState.AddTransition(disable);
             var disableToOn = disable.AddTransition(animatorState);
 
@@ -1411,7 +1412,7 @@ namespace ImTiara.FaceTrackingSetup
         public static void Save(params Object[] @objects)
         {
             AssetDatabase.Refresh();
-            
+
             foreach (var @object in @objects)
             {
                 if (@object != null)
@@ -1419,7 +1420,7 @@ namespace ImTiara.FaceTrackingSetup
                     EditorUtility.SetDirty(@object);
                 }
             }
-            
+
             AssetDatabase.SaveAssets();
             UnityEditor.SceneManagement.EditorSceneManager.SaveOpenScenes();
         }

--- a/FaceTrackingSetup/Scripts/Editor/FaceTrackingSetup_Editor.cs
+++ b/FaceTrackingSetup/Scripts/Editor/FaceTrackingSetup_Editor.cs
@@ -994,17 +994,20 @@ namespace ImTiara.FaceTrackingSetup
                         eyeLeftIdle = new AnimationClip();
                         eyeRightIdle = new AnimationClip();
 
-
+                        eyeLeftBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
                         eyeLeftBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftBlinkShapeKey}", AnimationCurve.Constant(0, 0, 100));
                         AssetDatabase.CreateAsset(eyeLeftBlink, $"{fts.outputPath}/Blinking/Eye_Left_Blink.anim");
 
+                        eyeRightBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
                         eyeRightBlink.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightBlinkShapeKey}", AnimationCurve.Constant(0, 0, 100));
                         AssetDatabase.CreateAsset(eyeRightBlink, $"{fts.outputPath}/Blinking/Eye_Right_Blink.anim");
 
                         eyeLeftWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftWideShapeKey}", AnimationCurve.Constant(0, 0, 100));
+                        eyeLeftWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
                         AssetDatabase.CreateAsset(eyeLeftWide, $"{fts.outputPath}/Blinking/Eye_Left_Wide.anim");
 
                         eyeRightWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightWideShapeKey}", AnimationCurve.Constant(0, 0, 100));
+                        eyeRightWide.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.rightBlinkShapeKey}", AnimationCurve.Constant(0, 0, 0));
                         AssetDatabase.CreateAsset(eyeRightWide, $"{fts.outputPath}/Blinking/Eye_Right_Wide.anim");
 
                         eyeLeftIdle.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.leftWideShapeKey}", AnimationCurve.Constant(0, 0, 0));
@@ -1118,12 +1121,14 @@ namespace ImTiara.FaceTrackingSetup
                 AnimationClip eyeConstricted = new AnimationClip();
 
                 eyeDilated.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.dilatedShapeKey}", AnimationCurve.Constant(0, 0, 100));
+                eyeDilated.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.constrictedShapeKey}", AnimationCurve.Constant(0, 0, 0));
                 AssetDatabase.CreateAsset(eyeDilated, $"{fts.outputPath}/Pupils/Eye_Dilated.anim");
 
                 eyeNormal.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.dilatedShapeKey}", AnimationCurve.Constant(0, 0, 0));
                 eyeNormal.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.constrictedShapeKey}", AnimationCurve.Constant(0, 0, 0));
                 AssetDatabase.CreateAsset(eyeNormal, $"{fts.outputPath}/Pupils/Eye_Normal.anim");
 
+                eyeConstricted.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.dilatedShapeKey}", AnimationCurve.Constant(0, 0, 0));
                 eyeConstricted.SetCurve(fts.faceMesh.name, typeof(SkinnedMeshRenderer), $"blendShape.{fts.constrictedShapeKey}", AnimationCurve.Constant(0, 0, 100));
                 AssetDatabase.CreateAsset(eyeConstricted, $"{fts.outputPath}/Pupils/Eye_Constricted.anim");
 

--- a/FaceTrackingSetup/Scripts/FaceTrackingSetup.cs
+++ b/FaceTrackingSetup/Scripts/FaceTrackingSetup.cs
@@ -101,6 +101,8 @@ namespace ImTiara.FaceTrackingSetup
         public AnimationClip rightBlinkAnimation;
         public AnimationClip leftWideAnimation;
         public AnimationClip rightWideAnimation;
+        public AnimationClip leftIdleAnimation;
+        public AnimationClip rightIdleAnimation;
 
         public float blinkingThreshold_Blink = BLINKING_BLINK;
         public float blinkingThreshold_Normal = BLINKING_NORMAL;


### PR DESCRIPTION
Added code to generate "Idle" anims to replace the _do_nothing animation.

For mouth tracking this fix works flawlessly.
Eye tracking did not require a fix.

Blink/pupil dilation will break if the user does not make a selection for all blendshapes.

Note: any layers with facial expressions will need to be placed below the face tracking layers to work, and will need it's own logic to disable when face tracking is enabled.